### PR TITLE
Feature/modify chunk size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+language: java
+jdk:
+  - oraclejdk8
+script: 
+  - mvn clean install
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 Dockstore s3cmd file provisioning plugin.  Requires s3cmd installed along with a valid configuration file.
 Run s3cmd --configure to create a configuration file at the default location.
 
+## Notes
+For files over 150 GB, chunk size is kept as close to the default chunk size as possible.  Files over 50 TB is unsupported.
+
 ## Usage
 
 The s3cmd plugin is capable of downloading files by calling out to an installed copy of the [s3cmd client](http://s3tools.org/s3cmd).

--- a/src/main/java/io/dockstore/provision/S3CmdPlugin.java
+++ b/src/main/java/io/dockstore/provision/S3CmdPlugin.java
@@ -98,7 +98,27 @@ public class S3CmdPlugin extends Plugin {
             // ambiguous how to reference s3cmd files, rip off these kinds of headers
             sourcePath = sourcePath.replaceFirst("s3cmd", "s3");
             String command = client + " -c " + configLocation + " get " + sourcePath + " " + destination + " --force";
-            return executeConsoleCommand(command, true);
+            int exitCode = executeConsoleCommand(command, true);
+            return checkExitCode(exitCode);
+        }
+
+        // This function checks the exit code and decides what to return
+        // See https://github.com/s3tools/s3cmd/blob/master/S3/ExitCodes.py for exit code description
+        private boolean checkExitCode(int exitCode) {
+            switch (exitCode) {
+            case 0: {
+                return true;
+            }
+            case 65:
+            case 71:
+            case 74:
+            case 75: {
+                return false;
+            }
+            default: {
+                throw new RuntimeException("Process exited with exit code" + exitCode);
+            }
+            }
         }
 
         /**
@@ -134,13 +154,15 @@ public class S3CmdPlugin extends Plugin {
             String trimmedPath = destPath.replace("s3://", "");
             List<String> splitPathList = Lists.newArrayList(trimmedPath.split("/"));
             String bucketName = splitPathList.remove(0);
-            if (checkBucket("s3://" + bucketName)) {
+            String fullBucketName = "s3://" + bucketName;
+            if (checkBucket(fullBucketName)) {
                 LOG.info("Bucket exists");
             } else {
-                createBucket(bucketName);
+                createBucket(fullBucketName);
             }
             String command = client + " -c " + configLocation + " put " + sourceFile.toString() + " " + destPath;
-            return executeConsoleCommand(command, true);
+            int exitCode = executeConsoleCommand(command, true);
+            return checkExitCode(exitCode);
         }
 
         /**
@@ -152,7 +174,12 @@ public class S3CmdPlugin extends Plugin {
         private boolean checkBucket(String bucket) {
             String command = client + " -c " + configLocation + " info " + bucket;
             LOG.info("Bucket information: ");
-            return executeConsoleCommand(command, false);
+            int exitCode = executeConsoleCommand(command, false);
+            if (exitCode != 0) {
+                return false;
+            } else {
+                return true;
+            }
         }
 
         /**
@@ -163,7 +190,12 @@ public class S3CmdPlugin extends Plugin {
          */
         private boolean createBucket(String bucket) {
             String command = client + " -c " + configLocation + " mb " + bucket;
-            return executeConsoleCommand(command, false);
+            int exitCode = executeConsoleCommand(command, false);
+            if (exitCode != 0) {
+                return false;
+            } else {
+                return true;
+            }
         }
 
         /**
@@ -172,7 +204,8 @@ public class S3CmdPlugin extends Plugin {
          * @param command The command to execute
          * @return True if command was successfully execute without error, false otherwise.
          */
-        private boolean executeConsoleCommand(String command, boolean printStdout) {
+        private int executeConsoleCommand(String command, boolean printStdout) {
+            System.out.println("Executing command: " + command);
             ProcessBuilder builder = new ProcessBuilder(command.split(" "));
             builder.redirectErrorStream(true);
             final Process p;
@@ -195,26 +228,27 @@ public class S3CmdPlugin extends Plugin {
                                 }
                             }
                         }
+                        if (command.contains("put") || command.contains("get")) {
+                            System.out.println();
+                        }
                         reader.close();
-                        System.out.println();
                     } catch (IOException e) {
                         LOG.error("Could not read input stream from process. " + e.getMessage());
+                        throw new RuntimeException(e);
                     }
                 });
                 ioThread.start();
                 try {
-                    if (p.waitFor() == 0) {
-                        return true;
-                    } else {
-                        return false;
-                    }
+                    int exitCode = p.waitFor();
+                    return exitCode;
                 } catch (InterruptedException e) {
                     LOG.error("Process interrupted. " + e.getMessage());
-                    return false;
+                    throw new RuntimeException(e);
                 }
             } catch (IOException e) {
                 LOG.error("Could not execute command: " + command);
-                return false;
+
+                throw new RuntimeException(e);
             }
         }
     }

--- a/src/main/java/io/dockstore/provision/S3CmdPlugin.java
+++ b/src/main/java/io/dockstore/provision/S3CmdPlugin.java
@@ -130,15 +130,9 @@ public class S3CmdPlugin extends Plugin {
             if (config == null) {
                 LOG.error("You are missing a dockstore config file");
             }
-            if (config.containsKey(CLIENT_LOCATION)) {
-                setClient(config.get(CLIENT_LOCATION));
-            } else {
-                setClient(DEFAULT_CLIENT);
-            }
-            if (config.containsKey(CONFIG_FILE_LOCATION)) {
-                setConfigLocation(config.get(CONFIG_FILE_LOCATION));
-            } else {
-                setConfigLocation(DEFAULT_CONFIGURATION);
+            else {
+                setConfigLocation(config.getOrDefault(CONFIG_FILE_LOCATION, DEFAULT_CONFIGURATION));
+                setClient(config.getOrDefault(CLIENT_LOCATION, DEFAULT_CLIENT));
             }
         }
 

--- a/src/main/java/io/dockstore/provision/S3CmdPluginHelper.java
+++ b/src/main/java/io/dockstore/provision/S3CmdPluginHelper.java
@@ -1,0 +1,29 @@
+package io.dockstore.provision;
+
+/**
+ * @author gluu
+ * @since 15/12/17
+ */
+public class S3CmdPluginHelper {
+    private static final long DEFAULT_CHUNK_SIZE = 15;
+    private static final long MAX_PARTS = 10000;
+    /**
+     * Calculates the chunk size for uploads and the flag to set it.
+     * If the file is under 150 GB, the chunk size is left as the default (15 MB).
+     * For files over 150 GB, the chunk size is kept as close to the default as possible with
+     * the number of chunks at the max limit (10 000).  More chunks and chunk-size closer to default is safer.
+     * Chunk size over 5 GB (passed the current limit) is automatically caught by s3cmd itself
+     *
+     * @param sizeInBytes Size of the file trying to upload in bytes
+     * @return
+     */
+    public static String getChunkSize(long sizeInBytes) {
+        String modifiedChunkSize = "";
+        double sizeInMegabytes = (double)sizeInBytes/1000000;
+        if (sizeInMegabytes > DEFAULT_CHUNK_SIZE*MAX_PARTS) {
+            long newChunkSize = (long)Math.ceil(sizeInMegabytes/MAX_PARTS);
+            modifiedChunkSize = " --multipart-chunk-size-mb=" + newChunkSize;
+        }
+        return modifiedChunkSize;
+    }
+}

--- a/src/test/java/io/dockstore/provision/S3CmdPluginTest.java
+++ b/src/test/java/io/dockstore/provision/S3CmdPluginTest.java
@@ -1,0 +1,22 @@
+package io.dockstore.provision;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author gluu
+ * @since 07/03/17
+ */
+public class S3CmdPluginTest {
+
+    @Test
+    public void getChunkSizeTest() {
+        String flag = S3CmdPluginHelper.getChunkSize(150000000001L);
+        assertEquals(" --multipart-chunk-size-mb=16", flag);
+        flag = S3CmdPluginHelper.getChunkSize(150000000000L);
+        assertEquals("", flag);
+        flag = S3CmdPluginHelper.getChunkSize(149999999999L);
+        assertEquals("", flag);
+    }
+}


### PR DESCRIPTION
This fixes two things.

- Modify chunk size when the size of the file is over 150 GB.  The chunk size is modified to be as small as possible while keeping the amount of chunks as high as possible (10 000).  Files larger than 50 TB (5 GB x 10 000 chunks) is still unsupported 
- Quick fix for the file paths with spaces in the source during upload.

TODO: Handle all spaces in the file paths, issue created.